### PR TITLE
Fix cleanup function

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ module.exports.withFile = function withFile(fn) {
 module.exports.dirSync = tmp.dirSync;
 var dir = Promise.promisify(tmp.dir, {multiArgs: true});
 module.exports.dir = function dir$promise() {
-  return dir.apply(tmp, arguments).spread(function (path, fd, cleanup) {
-    return {path: path, fd: fd, cleanup : cleanup };
+  return dir.apply(tmp, arguments).spread(function (path, cleanup) {
+    return {path: path, cleanup: cleanup};
   });
 };
 


### PR DESCRIPTION
The cleanup function doesn't work for directories.  The reason is that the wraper code expects a file descriptor but none is given for directories.  This fixes it.