### PR TITLE
Fix name of temporal directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports.file = function file$promise() {
 
 module.exports.withFile = function withFile(fn) {
   var cleanup;
-  return module.exports.file.apply(tmp, arguments).then(function context(o) { 
+  return module.exports.file.apply(tmp).then(function context(o) { 
     cleanup = o.cleanup;
     delete o.cleanup;
     return fn(o);


### PR DESCRIPTION
By using `arguments` it was being always set the temporal directory name to `/tmp/_tmpNameCreated` because it caught the name of the function. After removing it the folders are being created with a random name as it should be. Another maybe better option would be to use `Array.slice()` or `Array.shift()` to remove the `fn` function so options could be passed to underlying `tmp` module, like `unsafeCleanup`. What do you think?