### PR TITLE
Bump tmp dependency to tmp-0.0.31.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.1",
-    "tmp": "0.0.28"
+    "tmp": "0.0.31"
   },
   "devDependencies": {
     "mocha": "^3.1.2"


### PR DESCRIPTION
Unfortunately, as discussed at https://github.com/raszi/node-tmp/issues/75 ,
the tmp dependency only has an 0.x release. This means this library
has to manually bump and release for every upstream release to get
fixes and improvements.