### PR TITLE
Drop Bluebird as a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
 var tmp = require("tmp");
-var Promise = require("bluebird");
+require('promise-spread');
+const promisify = require("es6-promisify");
 
+Promise.prototype.finally = function(onResolveOrReject) {
+  return this.catch(function(reason){
+    return reason;
+  }).then(onResolveOrReject);
+};
 
 // file
 module.exports.fileSync = tmp.fileSync;
-var file = Promise.promisify(tmp.file, {multiArgs: true});
+var file = promisify(tmp.file, {multiArgs: true});
 
 module.exports.file = function file$promise() {
   return file.apply(tmp, arguments).spread(function (path, fd, cleanup) {
@@ -32,7 +38,7 @@ module.exports.withFile = function withFile(fn) {
 
 // directory
 module.exports.dirSync = tmp.dirSync;
-var dir = Promise.promisify(tmp.dir, {multiArgs: true});
+var dir = promisify(tmp.dir, {multiArgs: true});
 
 module.exports.dir = function dir$promise() {
   return dir.apply(tmp, arguments).spread(function (path, cleanup) {
@@ -60,7 +66,7 @@ module.exports.withDir = function withDir(fn) {
 
 // name generation
 module.exports.tmpNameSync = tmp.tmpNameSync;
-module.exports.tmpName = Promise.promisify(tmp.tmpName);
+module.exports.tmpName = promisify(tmp.tmpName);
 
 module.exports.tmpdir = tmp.tmpdir;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "git://github.com/benjamingr/tmp-promise.git"
   },
   "dependencies": {
-    "bluebird": "^3.3.1",
+    "es6-promisify": "^5.0.0",
+    "promise-spread": "^0.1.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
Bluebird doesn't play nice with Webpack:
https://github.com/webpack/webpack/issues/2674

This "not playing well" took the form of a `TypeError: makeNodePromisified is not a function` error when I tried to start my Electron app which used tmp-promise. 

This pull request solves a problem specific to my setup, but may be of interest to
others as well. Replacing a big complicated dependency with something
small and simple is probably a step forward.

