### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,13 @@
 import { fileSync, dirSync, tmpNameSync, setGracefulCleanup } from 'tmp';
 import { Options, SimpleOptions } from 'tmp';
 
-export interface FileResult {
-    name: string;
-    fd: number;
-    cleanup(): void;
-}
 export interface DirectoryResult {
     path: string;
     cleanup(): void;
+}
+
+export interface FileResult extends DirectoryResult {
+    fd: number;
 }
 
 export function file(options?: Options): Promise<FileResult>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+import { fileSync, dirSync, tmpNameSync, setGracefulCleanup } from 'tmp';
+import { Options, SimpleOptions } from 'tmp';
+
+export interface FileResult {
+    name: string;
+    fd: number;
+    cleanup(): void;
+}
+export interface DirectoryResult {
+    path: string;
+    cleanup(): void;
+}
+
+export function file(options?: Options): Promise<FileResult>;
+export function withFile<T>(fn: (result: FileResult) => Promise<T>): Promise<T>;
+
+export function dir(options?: Options): Promise<DirectoryResult>;
+export function withDir<T>(fn: (results: DirectoryResult) => Promise<T>): Promise<T>;
+
+export function tmpName(options?: SimpleOptions): Promise<string>; 
+
+export { fileSync, dirSync, tmpNameSync, setGracefulCleanup }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.4",
   "description": "The tmp package with promises support and disposers.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "mocha"
   },
@@ -24,6 +25,7 @@
     "tmp": "0.0.33"
   },
   "devDependencies": {
+    "@types/tmp": "0.0.33",
     "mocha": "^3.1.2"
   }
 }


### PR DESCRIPTION
This new file and tiny change to package.json allows this library to be natively used in Typescript projects. It does not effect anyone who is using plain javascript in their project.