### PR TITLE
Convert to util.promisify and async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "git://github.com/benjamingr/tmp-promise.git"
   },
   "dependencies": {
-    "bluebird": "^3.5.0",
     "tmp": "0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ref https://github.com/benjamingr/tmp-promise/issues/23#issuecomment-490112365

Rather than wrapping the callback generically, it seems clearest to produce the correct output value all at once.

I'm getting a test failure locally on `withDir`, though I have the same failure in master. Any ideas what's causing that?