### PR TITLE
Bump mocha from 3.1.2 to 6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/tmp": "0.1.0",
-    "mocha": "^3.1.2",
+    "mocha": "^6.1.4",
     "tsd": "^0.7.2"
   }
 }


### PR DESCRIPTION
This clears an npm security warrning.