### PR TITLE
Update types to handle tmp upgrade, with a test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,27 @@
-import { fileSync, dirSync, tmpNameSync, setGracefulCleanup } from 'tmp';
-import { Options, SimpleOptions } from 'tmp';
+import { fileSync, dirSync, tmpNameSync, setGracefulCleanup } from "tmp";
+import { FileOptions, DirOptions, TmpNameOptions } from "tmp";
 
 export interface DirectoryResult {
-    path: string;
-    cleanup(): void;
+  path: string;
+  cleanup(): void;
 }
 
 export interface FileResult extends DirectoryResult {
-    fd: number;
+  fd: number;
 }
 
-export function file(options?: Options): Promise<FileResult>;
-export function withFile<T>(fn: (result: FileResult) => Promise<T>, options?: Options): Promise<T>;
+export function file(options?: FileOptions): Promise<FileResult>;
+export function withFile<T>(
+  fn: (result: FileResult) => Promise<T>,
+  options?: FileOptions
+): Promise<T>;
 
-export function dir(options?: Options): Promise<DirectoryResult>;
-export function withDir<T>(fn: (results: DirectoryResult) => Promise<T>, options?: Options): Promise<T>;
+export function dir(options?: DirOptions): Promise<DirectoryResult>;
+export function withDir<T>(
+  fn: (results: DirectoryResult) => Promise<T>,
+  options?: DirOptions
+): Promise<T>;
 
-export function tmpName(options?: SimpleOptions): Promise<string>; 
+export function tmpName(options?: TmpNameOptions): Promise<string>;
 
-export { fileSync, dirSync, tmpNameSync, setGracefulCleanup }
+export { fileSync, dirSync, tmpNameSync, setGracefulCleanup };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,27 @@
+import { file, withFile, dir, withDir, tmpName } from ".";
+
+async function fileExample() {
+  const { path, fd, cleanup } = await file({ discardDescriptor: true });
+
+  await withFile(
+    async ({ path, fd, cleanup }) => {
+      console.log(fd);
+    },
+    { discardDescriptor: true }
+  );
+}
+
+async function dirExample() {
+  const { path, cleanup } = await dir({ unsafeCleanup: true });
+
+  await withDir(
+    async ({ path, cleanup }) => {
+      console.log(path);
+    },
+    { unsafeCleanup: true }
+  );
+}
+
+async function tmpNameExample() {
+  const name = await tmpName({ tries: 3 });
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "mocha"
+    "mocha": "mocha",
+    "check-types": "tsd",
+    "test": "npm run mocha && npm run check-types"
   },
   "keywords": [
     "tmp",
@@ -25,7 +27,8 @@
     "tmp": "0.1.0"
   },
   "devDependencies": {
-    "@types/tmp": "0.0.33",
-    "mocha": "^3.1.2"
+    "@types/tmp": "0.1.0",
+    "mocha": "^3.1.2",
+    "tsd": "^0.7.2"
   }
 }


### PR DESCRIPTION
These updates to the type definitions are compatible with the version of `@types/tmp` that match the version of `tmp` set in #24.

I formatted the types file automatically using Prettier. It now seems closer now to the format of `index.js`.

Side note: The type definitions probably should be listed as a dependency since `@types/tmp` is required for consuming the library from Typescript. It's admittedly a bit annoying that people who aren't using Typescript would then need that dependency. Let me know if you want to include it. I'm happy to update this.