### PR TITLE
Set up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2
+
+common_steps: &common_steps
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: npm install
+
+      - run:
+          name: Run tests
+          command: npm run mocha
+
+      - run:
+          name: Check Typescript types
+          command: npm run check-types
+          when: always
+
+jobs:
+  node-8:
+    docker:
+      - image: circleci/node:8
+
+    <<: *common_steps
+
+  node-10:
+    docker:
+      - image: circleci/node:10
+
+    <<: *common_steps
+
+  node-11:
+    docker:
+      - image: circleci/node:11
+
+    <<: *common_steps
+
+  node-12:
+    docker:
+      - image: circleci/node:12
+
+    <<: *common_steps
+
+workflows:
+  version: 2
+
+  on-commit:
+    jobs:
+      - node-8
+      - node-10
+      - node-11
+      - node-12


### PR DESCRIPTION
This is an alternative to for #15 / #12. See my comment at https://github.com/benjamingr/tmp-promise/issues/12#issuecomment-490137928.

I tested and iterated on this in my fork and you can see the successful run here: https://circleci.com/gh/paulmelnikow/tmp-promise/7.

To take advantage of this, you'd need to sign up for CircleCI yourself, and tell it to start building this repo:

https://circleci.com/docs/2.0/first-steps/

There isn't a way to delegate that without transferring the repo into a GitHub organization.

After you do that, I think this PR branch might build on its own. If not I can push another commit which should trigger the build.