### PR TITLE
Propagate errors instead of crashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@ const tmp = require("tmp");
 
 // file
 module.exports.fileSync = tmp.fileSync;
-const fileWithOptions = promisify(
-  (options, cb) => tmp.file(
-    options,
-    (err, path, fd, cleanup) => cb(err, {path, fd, cleanup: promisify(cleanup)})
+const fileWithOptions = promisify((options, cb) =>
+  tmp.file(options, (err, path, fd, cleanup) =>
+    err ? cb(err) : cb(undefined, { path, fd, cleanup: promisify(cleanup) })
   )
 );
 module.exports.file = async (options) => fileWithOptions(options);
@@ -23,10 +22,9 @@ module.exports.withFile = async function withFile(fn, options) {
 
 // directory
 module.exports.dirSync = tmp.dirSync;
-const dirWithOptions = promisify(
-  (options, cb) => tmp.dir(
-    options,
-    (err, path, cleanup) => cb(err, {path, cleanup: promisify(cleanup)})
+const dirWithOptions = promisify((options, cb) =>
+  tmp.dir(options, (err, path, cleanup) =>
+    err ? cb(err) : cb(undefined, { path, cleanup: promisify(cleanup) })
   )
 );
 module.exports.dir = async (options) => dirWithOptions(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmp-promise",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The tmp package with promises support and disposers.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test.js
+++ b/test.js
@@ -48,6 +48,15 @@ describe('file()', function()
       assert.ok(result.path.includes(prefix))
     })
   })
+
+  it('propagates errors', async function() {
+    try {
+      await tmp.file({ dir: 'nonexistent-path' });
+      throw Error('Expected to throw');
+    } catch (e) {
+      assert.ok(e.message.startsWith('ENOENT: no such file or directory'));
+    }
+  });
 })
 
 async function checkDirResult(result) {
@@ -84,6 +93,15 @@ describe('dir()', function()
       assert.ok(result.path.includes(prefix))
     })
   })
+
+  it('propagates errors', async function() {
+    try {
+      await tmp.dir({ dir: 'nonexistent-path' });
+      throw Error('Expected to throw');
+    } catch (e) {
+      assert.ok(e.message.startsWith('ENOENT: no such file or directory'));
+    }
+  });
 })
 
 describe('withFile()', function()


### PR DESCRIPTION
The bug was attempting to `promisify` a non-existent cleanup handler in case of errors. Now in case of an error, just emit the error. In case of an error there isn't a valid callback function (nor is the result passed through the promise anyway).

Fix #34