### PR TITLE
Move @types/tmp to production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "url": "git://github.com/benjamingr/tmp-promise.git"
   },
   "dependencies": {
+    "@types/tmp": "0.1.0",
     "tmp": "0.1.0"
   },
   "devDependencies": {
-    "@types/tmp": "0.1.0",
     "mocha": "^6.1.4",
     "tsd": "^0.7.2"
   }


### PR DESCRIPTION
Several types from `@types/tmp` package, such as FileOptions and DirOptions, are exposed as part of public typing in index.d.ts. This requires `@types/tmp` to be a production dependency instead of a devDependency, so that TypeScript consumers can find the correct typing for these options instead of `any`.