### PR TITLE
Fix `version` in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tmp-promise",
-  "version": "1.1.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The `version` in the `package-lock.json` is not in sync with the `package.json`.