### PR TITLE
Upgrade to latest `node-tmp`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tmp-promise",
-  "version": "1.1.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2314,9 +2314,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2730,11 +2730,11 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.0.tgz",
+      "integrity": "sha512-spsb5g6EiPmteS5TcOAECU3rltCMDMp4VMU2Sb0+WttN4qGobEkMAd+dkr1cubscN08JGNDX765dPbGImbG7MQ==",
       "requires": {
-        "rimraf": "^2.6.3"
+        "rimraf": "^3.0.0"
       }
     },
     "to-object-path": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "url": "git://github.com/benjamingr/tmp-promise.git"
   },
   "dependencies": {
-    "tmp": "0.1.0"
+    "tmp": "^0.2.0"
   },
   "devDependencies": {
-    "@types/tmp": "0.1.0",
+    "@types/tmp": "^0.1.0",
     "mocha": "^6.1.4",
     "tsd": "^0.7.2"
   }


### PR DESCRIPTION
This upgrades `tmp-promise` to latest [`node-tmp@0.2.0`](https://github.com/raszi/node-tmp/blob/master/CHANGELOG.md#tmp-v020).

I checked the breaking changes from that version, and no changes in `tmp-promise` should be required.

I have also submitted a PR (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44241) to upgrade the TypeScript types. When this is merged, I will upgrade them to `0.2.0`.

I am also adding `^` so that new patch versions of `node-tmp` do not require updates from `tmp-promise`.