### PR TITLE
typescript - Change the signature of cleanup to be an arrow function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { FileOptions, DirOptions, TmpNameOptions } from "tmp";
 
 export interface DirectoryResult {
   path: string;
-  cleanup(): Promise<void>;
+  cleanup: () => Promise<void>;
 }
 
 export interface FileResult extends DirectoryResult {


### PR DESCRIPTION
Super small change here, possibly subjective, I was getting [this eslint warning](https://github.com/typescript-eslint/typescript-eslint/blob/v5.1.0/packages/eslint-plugin/docs/rules/unbound-method.md):

![image](https://user-images.githubusercontent.com/7473960/138864122-8f5a0193-1d7c-4a76-a790-89fc095da469.png)

This is because when I take `cleanup` out of the object given by `file()`, eslint can't know whether cleanup will still work as I'm calling it without the object/this... changing cleanup to be an arrow function suppresses this error and indicates that it can be used on its own.

Yeah, I guess I can just turn this warning off, but where's the fun in that :)